### PR TITLE
ci/cd: publish package

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,23 @@
+name: Publish package to GitHub Packages
+on:
+  release:
+    types: [published]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v3
+      # Setup .npmrc file to publish to GitHub Packages
+      - uses: actions/setup-node@v3
+        with:
+          node-version: ">=16.x"
+          registry-url: "https://npm.pkg.github.com"
+          # Defaults to the user or organization that owns the workflow file
+          scope: "@octocat"
+      - run: npm ci
+      - run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,8 +15,6 @@ jobs:
         with:
           node-version: ">=16.x"
           registry-url: "https://npm.pkg.github.com"
-          # Defaults to the user or organization that owns the workflow file
-          scope: "@octocat"
       - run: npm ci
       - run: npm publish
         env:

--- a/package.json
+++ b/package.json
@@ -15,6 +15,12 @@
     "type": "git",
     "url": "https://github.com/kszinhu/ogm-neo4j.git"
   },
+  "engines": {
+    "node": ">=16.0.0"
+  },
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com"
+  },
   "author": {
     "name": "Cassiano Henrique Aparecido Rodrigues",
     "email": "kszinhu@modscleo4.dev.br"


### PR DESCRIPTION
# Publish package on `Github Packages`

This branch adds workflow to publish package

## Description

When the posting event of type published is triggered. If the CI tests pass, the process uploads the package to GitHub Packages.